### PR TITLE
Mixnet: Use gossip for broadcasting (after mix)

### DIFF
--- a/mixnet/config.ci.yaml
+++ b/mixnet/config.ci.yaml
@@ -15,7 +15,7 @@ network:
     max_latency_sec: 0.1
     # Seed for the random number generator used to determine the network latencies.
     seed: 0
-  nomssip:
+  gossip:
     # Expected number of peers each node must connect to if there are enough peers available in the network.
     peering_degree: 4
 

--- a/mixnet/protocol/config.py
+++ b/mixnet/protocol/config.py
@@ -8,6 +8,8 @@ from pysphinx.node import X25519PublicKey
 from pysphinx.sphinx import Node as SphinxNode
 from pysphinx.sphinx import X25519PrivateKey
 
+from protocol.gossip import GossipConfig
+
 
 @dataclass
 class GlobalConfig:
@@ -29,13 +31,7 @@ class NodeConfig:
 
     private_key: X25519PrivateKey
     mix_path_length: int
-    nomssip: NomssipConfig
-
-
-@dataclass
-class NomssipConfig:
-    # Expected number of peers each node must connect to if there are enough peers available in the network.
-    peering_degree: int
+    gossip: GossipConfig
 
 
 @dataclass

--- a/mixnet/protocol/connection.py
+++ b/mixnet/protocol/connection.py
@@ -41,7 +41,7 @@ class DuplexConnection:
     This is to mimic duplex communication in a real network (such as TCP or QUIC).
     """
 
-    def __init__(self, inbound: SimplexConnection, outbound: MixSimplexConnection):
+    def __init__(self, inbound: SimplexConnection, outbound: SimplexConnection):
         self.inbound = inbound
         self.outbound = outbound
 
@@ -52,7 +52,7 @@ class DuplexConnection:
         await self.outbound.send(packet)
 
 
-class MixSimplexConnection:
+class MixSimplexConnection(SimplexConnection):
     """
     Wraps a SimplexConnection to add a transmission rate and noise to the connection.
     """
@@ -82,5 +82,8 @@ class MixSimplexConnection:
                 msg = await self.queue.get()
             await self.conn.send(msg)
 
-    async def send(self, msg: bytes):
-        await self.queue.put(msg)
+    async def send(self, data: bytes) -> None:
+        await self.queue.put(data)
+
+    async def recv(self) -> bytes:
+        return await self.conn.recv()

--- a/mixnet/protocol/gossip.py
+++ b/mixnet/protocol/gossip.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from enum import Enum
+from typing import Awaitable, Callable, Self
+
+from framework import Framework
+from protocol.connection import (
+    DuplexConnection,
+    MixSimplexConnection,
+    SimplexConnection,
+)
+from protocol.error import PeeringDegreeReached
+
+
+@dataclass
+class GossipConfig:
+    # Expected number of peers each node must connect to if there are enough peers available in the network.
+    peering_degree: int
+
+
+class Gossip:
+    """
+    A gossip channel that broadcasts messages to all connected peers.
+    Peers are connected via DuplexConnection.
+    """
+
+    def __init__(
+        self,
+        framework: Framework,
+        config: GossipConfig,
+        handler: Callable[[bytes], Awaitable[None]],
+    ):
+        self.framework = framework
+        self.config = config
+        self.conns: list[DuplexConnection] = []
+        # A handler to process inbound messages.
+        self.handler = handler
+        self.packet_cache: set[bytes] = set()
+        # A set just for gathering a reference of tasks to prevent them from being garbage collected.
+        # https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task
+        self.tasks: set[Awaitable] = set()
+
+    def can_accept_conn(self) -> bool:
+        return len(self.conns) < self.config.peering_degree
+
+    def add_conn(self, inbound: SimplexConnection, outbound: SimplexConnection):
+        if not self.can_accept_conn():
+            # For simplicity of the spec, reject the connection if the peering degree is reached.
+            raise PeeringDegreeReached()
+
+        conn = DuplexConnection(
+            inbound,
+            outbound,
+        )
+        self.conns.append(conn)
+        task = self.framework.spawn(self.__process_inbound_conn(conn))
+        self.tasks.add(task)
+
+    async def __process_inbound_conn(self, conn: DuplexConnection):
+        while True:
+            msg = await conn.recv()
+            if self.__check_update_cache(msg):
+                continue
+            await self.process_inbound_msg(msg)
+
+    async def process_inbound_msg(self, msg: bytes):
+        await self.gossip(msg)
+        await self.handler(msg)
+
+    async def gossip(self, msg: bytes):
+        """
+        Gossip a message to all connected peers.
+        """
+        for conn in self.conns:
+            await conn.send(msg)
+
+    def __check_update_cache(self, packet: bytes) -> bool:
+        """
+        Add a message to the cache, and return True if the message was already in the cache.
+        """
+        hash = hashlib.sha256(packet).digest()
+        if hash in self.packet_cache:
+            return True
+        self.packet_cache.add(hash)
+        return False

--- a/mixnet/protocol/node.py
+++ b/mixnet/protocol/node.py
@@ -12,7 +12,7 @@ from framework import Framework, Queue
 from protocol.config import GlobalConfig, NodeConfig
 from protocol.connection import SimplexConnection
 from protocol.error import PeeringDegreeReached
-from protocol.nomssip import Nomssip
+from protocol.nomssip import Nomssip, NomssipConfig
 from protocol.sphinx import SphinxPacketBuilder
 
 BroadcastChannel = Queue[bytes]
@@ -34,9 +34,9 @@ class Node:
         self.global_config = global_config
         self.nomssip = Nomssip(
             framework,
-            Nomssip.Config(
+            NomssipConfig(
+                config.gossip.peering_degree,
                 global_config.transmission_rate_per_sec,
-                config.nomssip.peering_degree,
                 self.__calculate_message_size(global_config),
             ),
             self.__process_msg,

--- a/mixnet/protocol/nomssip.py
+++ b/mixnet/protocol/nomssip.py
@@ -41,7 +41,7 @@ class Nomssip(Gossip):
         noise_packet = FlaggedPacket(
             FlaggedPacket.Flag.NOISE, bytes(self.config.msg_size)
         ).bytes()
-        return super().add_conn(
+        super().add_conn(
             inbound,
             MixSimplexConnection(
                 self.framework,

--- a/mixnet/protocol/test_utils.py
+++ b/mixnet/protocol/test_utils.py
@@ -5,8 +5,8 @@ from protocol.config import (
     MixMembership,
     NodeConfig,
     NodeInfo,
-    NomssipConfig,
 )
+from protocol.gossip import GossipConfig
 
 
 def init_mixnet_config(
@@ -14,7 +14,7 @@ def init_mixnet_config(
     max_message_size: int = 512,
     max_mix_path_length: int = 3,
 ) -> tuple[GlobalConfig, list[NodeConfig], dict[bytes, X25519PrivateKey]]:
-    gossip_config = NomssipConfig(peering_degree=6)
+    gossip_config = GossipConfig(peering_degree=6)
     node_configs = [
         NodeConfig(X25519PrivateKey.generate(), max_mix_path_length, gossip_config)
         for _ in range(num_nodes)

--- a/mixnet/sim/config.py
+++ b/mixnet/sim/config.py
@@ -8,7 +8,8 @@ import dacite
 import yaml
 from pysphinx.sphinx import X25519PrivateKey
 
-from protocol.config import NodeConfig, NomssipConfig
+from protocol.config import NodeConfig
+from protocol.gossip import GossipConfig
 
 
 @dataclass
@@ -35,7 +36,7 @@ class Config:
             NodeConfig(
                 self.__gen_private_key(i),
                 self.mix.mix_path.random_length(),
-                self.network.nomssip,
+                self.network.gossip,
             )
             for i in range(self.network.num_nodes)
         ]
@@ -63,7 +64,7 @@ class NetworkConfig:
     # Total number of nodes in the entire network.
     num_nodes: int
     latency: LatencyConfig
-    nomssip: NomssipConfig
+    gossip: GossipConfig
 
     def __post_init__(self):
         assert self.num_nodes > 0

--- a/mixnet/sim/simulation.py
+++ b/mixnet/sim/simulation.py
@@ -1,4 +1,3 @@
-import json
 from dataclasses import asdict, dataclass
 from typing import Self
 
@@ -73,7 +72,12 @@ class Simulation:
 
         # Initialize Node instances
         nodes = [
-            Node(self.framework, node_config, global_config)
+            Node(
+                self.framework,
+                node_config,
+                global_config,
+                self.__process_broadcasted_msg,
+            )
             for node_config in node_configs
         ]
 
@@ -87,20 +91,26 @@ class Simulation:
             node_states = node_state_table[i]
             peer_states = node_state_table[peer_idx]
 
-            # Create simplex inbound/outbound connections
-            # and use them to connect node and peer.
+            # Connect the node and peer for Nomssip
             inbound_conn, outbound_conn = (
-                self.__create_conn(meter_start_time, peer_states, node_states),
-                self.__create_conn(meter_start_time, node_states, peer_states),
+                self.__create_observed_conn(meter_start_time, peer_states, node_states),
+                self.__create_observed_conn(meter_start_time, node_states, peer_states),
             )
-            node.connect(peer, inbound_conn, outbound_conn)
+            node.connect_mix(peer, inbound_conn, outbound_conn)
             # Register the connections to the connection statistics
             conn_stats.register(node, inbound_conn, outbound_conn)
             conn_stats.register(peer, outbound_conn, inbound_conn)
 
+            # Connect the node and peer for broadcasting.
+            node.connect_broadcast(
+                peer,
+                self.__create_conn(meter_start_time),
+                self.__create_conn(meter_start_time),
+            )
+
         return nodes
 
-    def __create_conn(
+    def __create_observed_conn(
         self,
         meter_start_time: float,
         sender_states: list[NodeState],
@@ -114,6 +124,16 @@ class Simulation:
             receiver_states,
         )
 
+    def __create_conn(
+        self,
+        meter_start_time: float,
+    ) -> MeteredRemoteSimplexConnection:
+        return MeteredRemoteSimplexConnection(
+            self.config.network.latency,
+            self.framework,
+            meter_start_time,
+        )
+
     async def __run_node_logic(self, node: Node):
         """
         Runs the lottery periodically to check if the node is selected to send a block.
@@ -124,3 +144,9 @@ class Simulation:
             await self.framework.sleep(lottery_config.interval_sec)
             if lottery_config.seed.random() < lottery_config.probability:
                 await node.send_message(b"selected block")
+
+    async def __process_broadcasted_msg(self, msg: bytes):
+        """
+        Process a message broadcasted after being travelled through mix nodes.
+        """
+        pass

--- a/mixnet/sim/simulation.py
+++ b/mixnet/sim/simulation.py
@@ -1,3 +1,7 @@
+import json
+from dataclasses import asdict, dataclass
+from typing import Self
+
 import usim
 from matplotlib import pyplot
 


### PR DESCRIPTION
Previously, we were using a dummy queue for the broadcast channel, as a dummy implementation. That queue was not connected between nodes because we were focusing on implementing mix traffic first.

Now, we need the actual broadcast channel, so that we can measure the message travel time (mix phase & broadcast phase). 

- 7287a94797e7d33d72e56b8dce3ee9a25b721aa4: 
  - I defined the `Gossip` class that implements the basic gossiping (that doesn't have GTR and noise).
  - I modified the `Nomssip` class to extend the `Gossip` class.
- 7801ead600c2cc7f7911a2a2b636733ce7482dd0: Each node has two separate channels. One is the `Nomssip`, and the other is the `Gossip`.
  - As before, we use the `Nomssip` for mix traffic. `Nomssip` has GTR and noise.
  - We use the `Gossip` for broadcasting (triggered by the last mix).
  - Those two channels are totally independent. They don't share connections. They can have different topology. 
    - In real world, they might be not independent. But in the simulation, we assume that they are independent for simplicity and clear analysis.

In next PRs, we are going to measure the message travel time.