### PR TITLE
Count # of messages broadcasted by each node

### DIFF
--- a/network-runner/src/node/mix/mod.rs
+++ b/network-runner/src/node/mix/mod.rs
@@ -133,6 +133,7 @@ impl MixNode {
                 node_id: id,
                 mock_counter: 0,
                 step_id: 0,
+                num_messages_broadcasted: 0,
             },
             persistent_sender,
             persistent_update_time_sender,
@@ -195,7 +196,8 @@ impl Node for MixNode {
                     persistent_sender.send(msg).unwrap();
                 }
                 MixOutgoingMessage::FullyUnwrapped(_) => {
-                    //TODO: increase counter and create a tracing event
+                    self.state.num_messages_broadcasted += 1;
+                    //TODO: create a tracing event
                 }
             }
         }

--- a/network-runner/src/node/mix/state.rs
+++ b/network-runner/src/node/mix/state.rs
@@ -14,6 +14,7 @@ pub struct MixnodeState {
     pub node_id: NodeId,
     pub mock_counter: usize,
     pub step_id: usize,
+    pub num_messages_broadcasted: usize,
 }
 
 #[derive(Serialize)]


### PR DESCRIPTION
This PR just adds a counter to the `MixnodeState` to count the number of messages broadcasted. We need to implement the warding as well, but @bacv will help for that.