### PR TITLE
Generate data message by running stake lottery

### DIFF
--- a/network-runner/src/bin/app/main.rs
+++ b/network-runner/src/bin/app/main.rs
@@ -101,6 +101,8 @@ impl SimulationApp {
                             .filter(|&id| id != &node_id)
                             .copied()
                             .choose_multiple(&mut rng, 3),
+                        data_message_lottery_interval: Duration::from_secs(20),
+                        stake_proportion: 1.0 / node_ids.len() as f64,
                         seed: 0,
                         persistent_transmission: PersistentTransmissionSettings {
                             max_emission_frequency: 1.0,

--- a/network-runner/src/node/mix/lottery.rs
+++ b/network-runner/src/node/mix/lottery.rs
@@ -1,0 +1,22 @@
+use rand::Rng;
+
+pub struct StakeLottery<R> {
+    rng: R,
+    stake_proportion: f64,
+}
+
+impl<R> StakeLottery<R>
+where
+    R: Rng,
+{
+    pub fn new(rng: R, stake_proportion: f64) -> Self {
+        Self {
+            rng,
+            stake_proportion,
+        }
+    }
+
+    pub fn run(&mut self) -> bool {
+        self.rng.gen_range(0.0..1.0) < self.stake_proportion
+    }
+}


### PR DESCRIPTION
Each node has a stake.
Each node run a lottery based on its stake proportion periodically. The interval of running lottery is set to 20 seconds in our config for now.