### PR TITLE
Disable drop messages

### DIFF
--- a/network-runner/src/bin/app/main.rs
+++ b/network-runner/src/bin/app/main.rs
@@ -104,7 +104,7 @@ impl SimulationApp {
                         seed: 0,
                         persistent_transmission: PersistentTransmissionSettings {
                             max_emission_frequency: 1.0,
-                            drop_message_probability: 0.5,
+                            drop_message_probability: 0.0,
                         },
                         message_blend: MessageBlendSettings {
                             cryptographic_processor: CryptographicProcessorSettings {


### PR DESCRIPTION
We've discussed to deprecate generating drop messages in the Nomos Blend protocol