### PR TITLE
Accumulate inbound/outbound message counts for anonymity measurement

### DIFF
--- a/simlib/mixnet-sims/src/node/mix/mod.rs
+++ b/simlib/mixnet-sims/src/node/mix/mod.rs
@@ -192,6 +192,8 @@ impl MixNode {
                 step_id: 0,
                 data_messages_generated: HashMap::new(),
                 data_messages_fully_unwrapped: HashMap::new(),
+                accum_num_inbound_messages: 0,
+                accum_num_outbound_messages: 0,
             },
             data_msg_lottery_update_time_sender,
             data_msg_lottery_interval,
@@ -220,13 +222,15 @@ impl MixNode {
             .filter(|&id| Some(*id) != exclude_node)
         {
             self.network_interface
-                .send_message(*node_id, message.clone())
+                .send_message(*node_id, message.clone());
+            self.state.accum_num_outbound_messages += 1;
         }
     }
 
     fn receive(&mut self) -> Vec<NetworkMessage<MixMessage>> {
-        self.network_interface
-            .receive_messages()
+        let received_messages = self.network_interface.receive_messages();
+        self.state.accum_num_inbound_messages += received_messages.len();
+        received_messages
             .into_iter()
             // Retain only messages that have not been seen before
             .filter(|msg| self.message_cache.insert(Self::sha256(&msg.payload().0)))

--- a/simlib/mixnet-sims/src/node/mix/state.rs
+++ b/simlib/mixnet-sims/src/node/mix/state.rs
@@ -16,8 +16,12 @@ pub struct MixnodeState {
     #[serde(serialize_with = "serialize_node_id_as_index")]
     pub node_id: NodeId,
     pub step_id: usize,
+    // For latency measurement
     pub data_messages_generated: HashMap<PayloadId, usize>,
     pub data_messages_fully_unwrapped: HashMap<PayloadId, usize>,
+    // For anonymity measurement
+    pub accum_num_inbound_messages: usize,
+    pub accum_num_outbound_messages: usize,
 }
 
 #[derive(Serialize)]


### PR DESCRIPTION
We've discussed that anonymity may be able to be measured by comparing the difference between the # of inbound and outbound messages in each time frame. 

So, in this simulation, in each step, each node accumulates the number of inbound/outbound messages. These numbers are stored in the state of each node.

Because the state of all nodes are printed in every step, and because the numbers are accumulative, the analysis tool should calculate a delta between the number at the step `s` and the step `s+t`.
The `t` should be configurable. It might be 20s but I'm not sure at this moment.