### PR TITLE
Add number_of_hops (for cover traffic) in config

### DIFF
--- a/simlib/mixnet-sims/config/mixnode.json
+++ b/simlib/mixnet-sims/config/mixnode.json
@@ -38,11 +38,12 @@
   "stake_proportion": 1.0,
   "epoch_duration": "432000s",
   "slot_duration": "1s",
+  "slots_per_epoch": 432000,
+  "number_of_hops": 1,
   "persistent_transmission": {
     "max_emission_frequency": 1.0,
     "drop_message_probability": 0.0
   },
   "number_of_mix_layers": 1,
-  "max_delay_seconds": 10,
-  "slots_per_epoch": 432000
+  "max_delay_seconds": 10
 }

--- a/simlib/mixnet-sims/src/main.rs
+++ b/simlib/mixnet-sims/src/main.rs
@@ -123,7 +123,7 @@ impl SimulationApp {
                         },
                         cover_traffic_settings: CoverTrafficSettings {
                             node_id: node_id.0,
-                            number_of_hops: settings.number_of_mix_layers,
+                            number_of_hops: settings.number_of_hops,
                             slots_per_epoch: settings.slots_per_epoch,
                             network_size: node_ids.len(),
                         },

--- a/simlib/mixnet-sims/src/settings.rs
+++ b/simlib/mixnet-sims/src/settings.rs
@@ -11,14 +11,18 @@ pub struct SimSettings {
     #[serde(deserialize_with = "deserialize_duration_with_human_time")]
     pub data_message_lottery_interval: Duration,
     pub stake_proportion: f64,
+    // For tier 3: cover traffic
     #[serde(deserialize_with = "deserialize_duration_with_human_time")]
     pub epoch_duration: Duration,
     #[serde(deserialize_with = "deserialize_duration_with_human_time")]
     pub slot_duration: Duration,
+    pub slots_per_epoch: usize,
+    pub number_of_hops: usize,
+    // For tier 1
     pub persistent_transmission: PersistentTransmissionSettings,
+    // For tier 2
     pub number_of_mix_layers: usize,
     pub max_delay_seconds: u64,
-    pub slots_per_epoch: usize,
 }
 
 fn deserialize_duration_with_human_time<'de, D>(deserializer: D) -> Result<Duration, D::Error>


### PR DESCRIPTION
Although we already have the `number_of_mix_layers` param for the tier 2, we need the `number_of_hops` for tier 3 to calculate the winning probability of cover traffic. In general, those two must be the same, but in the simulation, we want to have the full control of winning probabilitly regardless of the `number_of_mix_layers`.