### PR TITLE
Set cache after forwarding

### DIFF
--- a/simlib/mixnet-sims/src/node/mix/mod.rs
+++ b/simlib/mixnet-sims/src/node/mix/mod.rs
@@ -211,13 +211,6 @@ impl MixNode {
     }
 
     fn forward(&mut self, message: MixMessage, exclude_node: Option<NodeId>) {
-        if self
-            .message_cache
-            .cache_set(Self::sha256(&message.0), ())
-            .is_some()
-        {
-            return;
-        }
         for node_id in self
             .settings
             .connected_peers
@@ -227,6 +220,7 @@ impl MixNode {
             self.network_interface
                 .send_message(*node_id, message.clone())
         }
+        self.message_cache.cache_set(Self::sha256(&message.0), ());
     }
 
     fn receive(&mut self) -> Vec<NetworkMessage<MixMessage>> {


### PR DESCRIPTION
This bug was found/fix by @AlejandroCabeza and @danielSanchezQ 

Previously, we were setting a message to the cache right before forwarding the message to peers. Also, we set a message to the cache right after the message is received from the network.
Then, when we try to immediately forward the received message to peers, the cache deduplicates it. Then, the message is not forwarded in the end. 

To resolve this, we just forward the message first and set it to the cache. 