### PR TITLE
Log emmission events for anonymity analysis

### DIFF
--- a/simlib/mixnet-sims/src/node/mix/mod.rs
+++ b/simlib/mixnet-sims/src/node/mix/mod.rs
@@ -210,7 +210,7 @@ impl MixNode {
         }
     }
 
-    fn forward(&mut self, message: MixMessage, exclude_node: Option<NodeId>) {
+    fn forward(&mut self, message: MixMessage, exclude_node: Option<NodeId>, log: EmissionLog) {
         if self
             .message_cache
             .cache_set(Self::sha256(&message.0), ())
@@ -218,12 +218,16 @@ impl MixNode {
         {
             return;
         }
-        for node_id in self
+        for (i, node_id) in self
             .settings
             .connected_peers
             .iter()
             .filter(|&id| Some(*id) != exclude_node)
+            .enumerate()
         {
+            if i == 0 {
+                Self::log_emission(&log);
+            }
             self.network_interface
                 .send_message(*node_id, message.clone())
         }
@@ -270,8 +274,21 @@ impl MixNode {
         let log = MessageLog {
             payload_id: payload.id(),
             step_id: self.state.step_id,
+            node_id: format!("{}", self.id),
         };
         tracing::info!("{}: {}", tag, serde_json::to_string(&log).unwrap());
+    }
+
+    fn log_emission(log: &EmissionLog) {
+        tracing::info!("Emission: {}", serde_json::to_string(log).unwrap());
+    }
+
+    fn new_emission_log(&self, emission_type: &str) -> EmissionLog {
+        EmissionLog {
+            emission_type: emission_type.to_string(),
+            step_id: self.state.step_id,
+            node_id: format!("{}", self.id),
+        }
     }
 }
 
@@ -311,6 +328,7 @@ impl Node for MixNode {
             self.forward(
                 network_message.payload().clone(),
                 Some(network_message.from),
+                self.new_emission_log("ImmediateForwarding"),
             );
             self.blend_sender
                 .send(network_message.into_payload().0)
@@ -347,7 +365,11 @@ impl Node for MixNode {
         if let Poll::Ready(Some(msg)) =
             pin!(&mut self.persistent_transmission_messages).poll_next(&mut cx)
         {
-            self.forward(MixMessage(msg), None);
+            self.forward(
+                MixMessage(msg),
+                None,
+                self.new_emission_log("FromPersistent"),
+            );
         }
 
         self.state.step_id += 1;
@@ -368,4 +390,12 @@ impl Node for MixNode {
 struct MessageLog {
     payload_id: PayloadId,
     step_id: usize,
+    node_id: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct EmissionLog {
+    emission_type: String,
+    step_id: usize,
+    node_id: String,
 }


### PR DESCRIPTION
I devised a simpler way to measure the anonymity. 

We log every emission (forward) events. There are two big types of emissions. One is the immediate forwarding, and the other is emitting messages released from the Tier 1: Persistent Transmission.
For only the anonymity analysis, the logs of immediate forwarding can probably be ignored. But I’m logging all emissions with a type tag, just in case. 

Unlike the logging for latency analysis, here we print logs "right before" sending messages to peers, because the outsider observers can only see the network traffic between nodes, not inside logic of nodes.

In the analysis tool, we can draw a chart (e.g. scatter plot) to see the distribution of emission events across nodes over time. The goal of the blend protocol is having several nodes who emit "some" messages while a certain node is emitting a data message in a certain time frame, in order to hide who is the data message sender. In our protocol, each node sends not only cover messages, but also unpacked messages. These two can obfuscate the observation of outsider. For example, if there are 20 nodes emitting a cover message while a node is emitting a data message, it's not easy for the outside observer to guess who is the data message sender.