### PR TITLE
Fix netrunner tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,6 @@ jobs:
       - name: Build
         working-directory: simlib
         run: cargo build -v
-      # TODO: uncomment this after fixing tests
-      # - name: Unit tests
-      #   working-directory: simlib
-      #   run: cargo test -v
+      - name: Unit tests
+        working-directory: simlib
+        run: cargo test -v

--- a/simlib/netrunner/src/network/mod.rs
+++ b/simlib/netrunner/src/network/mod.rs
@@ -524,7 +524,7 @@ mod tests {
 
     impl PayloadSize for () {
         fn size_bytes(&self) -> u32 {
-            todo!()
+            0
         }
     }
 

--- a/simlib/netrunner/src/network/regions.rs
+++ b/simlib/netrunner/src/network/regions.rs
@@ -156,7 +156,6 @@ pub fn create_regions<R: Rng>(
 mod tests {
     use std::collections::HashMap;
 
-    use consensus_engine::NodeId;
     use rand::rngs::mock::StepRng;
 
     use crate::{
@@ -164,7 +163,7 @@ mod tests {
             regions::{create_regions, Region},
             NetworkSettings,
         },
-        node::NodeIdExt,
+        node::{NodeId, NodeIdExt},
     };
 
     #[test]

--- a/simlib/netrunner/src/node/dummy_streaming.rs
+++ b/simlib/netrunner/src/node/dummy_streaming.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
+use crate::warding::WardCondition;
+
 use super::{Node, NodeId};
 
 #[derive(Debug, Default, Copy, Clone, Serialize, Deserialize)]
@@ -40,6 +42,16 @@ impl<S> Node for DummyStreamingNode<S> {
     }
 
     fn step(&mut self, _: Duration) {
-        todo!()
+        self.state.counter += 1;
+    }
+
+    fn analyze(&self, ward: &mut crate::warding::WardCondition) -> bool {
+        match ward {
+            WardCondition::Max(ward) => self.state.counter >= ward.max_count,
+            WardCondition::Sum(condition) => {
+                *condition.step_result.borrow_mut() += self.state.counter;
+                false
+            }
+        }
     }
 }

--- a/simlib/netrunner/src/node/mod.rs
+++ b/simlib/netrunner/src/node/mod.rs
@@ -163,8 +163,14 @@ impl Node for usize {
         self.add_assign(1);
     }
 
-    fn analyze(&self, _: &mut WardCondition) -> bool {
-        todo!()
+    fn analyze(&self, ward: &mut WardCondition) -> bool {
+        match ward {
+            WardCondition::Max(ward) => *self >= ward.max_count,
+            WardCondition::Sum(condition) => {
+                *condition.step_result.borrow_mut() += *self;
+                false
+            }
+        }
     }
 }
 

--- a/simlib/netrunner/src/streaming/io.rs
+++ b/simlib/netrunner/src/streaming/io.rs
@@ -117,8 +117,6 @@ where
 mod tests {
     use std::{collections::HashMap, time::Duration};
 
-    use consensus_engine::View;
-
     use crate::{
         network::{
             behaviour::NetworkBehaviour,
@@ -135,12 +133,13 @@ mod tests {
     };
 
     use super::*;
+
     #[derive(Debug, Clone, Serialize)]
-    struct IORecord {
-        states: HashMap<NodeId, View>,
+    struct IORecord<T> {
+        states: HashMap<NodeId, T>,
     }
 
-    impl<S, T: Serialize> TryFrom<&SimulationState<S, T>> for IORecord {
+    impl<S, T: Serialize + Clone> TryFrom<&SimulationState<S, T>> for IORecord<T> {
         type Error = anyhow::Error;
 
         fn try_from(value: &SimulationState<S, T>) -> Result<Self, Self::Error> {
@@ -148,7 +147,7 @@ mod tests {
             Ok(Self {
                 states: nodes
                     .iter()
-                    .map(|node| (node.id(), node.current_view()))
+                    .map(|node| (node.id(), node.state().clone()))
                     .collect(),
             })
         }

--- a/simlib/netrunner/src/streaming/runtime_subscriber.rs
+++ b/simlib/netrunner/src/streaming/runtime_subscriber.rs
@@ -103,8 +103,6 @@ where
 mod tests {
     use std::{collections::HashMap, time::Duration};
 
-    use consensus_engine::View;
-
     use crate::{
         network::{
             behaviour::NetworkBehaviour,
@@ -122,11 +120,11 @@ mod tests {
 
     use super::*;
     #[derive(Debug, Clone, Serialize)]
-    struct RuntimeRecord {
-        states: HashMap<NodeId, View>,
+    struct RuntimeRecord<T> {
+        states: HashMap<NodeId, T>,
     }
 
-    impl<S, T: Serialize> TryFrom<&SimulationState<S, T>> for RuntimeRecord {
+    impl<S, T: Serialize + Clone> TryFrom<&SimulationState<S, T>> for RuntimeRecord<T> {
         type Error = anyhow::Error;
 
         fn try_from(value: &SimulationState<S, T>) -> Result<Self, Self::Error> {
@@ -135,7 +133,7 @@ mod tests {
                     .nodes
                     .read()
                     .iter()
-                    .map(|node| (node.id(), node.current_view()))
+                    .map(|node| (node.id(), node.state().clone()))
                     .collect(),
             })
         }

--- a/simlib/netrunner/src/streaming/settings_subscriber.rs
+++ b/simlib/netrunner/src/streaming/settings_subscriber.rs
@@ -102,9 +102,7 @@ where
 #[cfg(test)]
 mod tests {
     use std::collections::HashSet;
-    use std::{collections::HashMap, time::Duration};
-
-    type View = usize;
+    use std::time::Duration;
 
     use crate::{
         network::{


### PR DESCRIPTION
Fixed compile errors in netrunner, and enabled `cargo test` in CI. This is a preliminary work for adding new features and tests in blendnet-sims.